### PR TITLE
Add animated loading component for dynamic imports

### DIFF
--- a/app/fretboard/page.tsx
+++ b/app/fretboard/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import Loading from "@/src/components/Loading";
 
 export const metadata: Metadata = {
   title: "Fretboard - Guitar Grok",
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
 
 const Fretboard = dynamic(() => import("@/src/components/Fretboard"), {
   ssr: false,
-  loading: () => <div className="p-4">Loading...</div>,
+  loading: () => <Loading />,
 });
 
 export default function FretboardPage() {

--- a/app/mvp/page.tsx
+++ b/app/mvp/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
+import Loading from "@/src/components/Loading";
 
 export const metadata: Metadata = {
   title: "Guitar Daily - Guitar Grok",
@@ -10,7 +11,7 @@ const GuitarDailyMvp = dynamic(
   () => import("@/src/components/GuitarDailyMvp"),
   {
     ssr: false,
-    loading: () => <div className="p-4">Loading...</div>,
+    loading: () => <Loading />,
   }
 );
 

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center p-4" role="status" aria-label="Loading">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-white/20 border-t-white" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable animated loading spinner
- use animated loader for Fretboard and MVP dynamic imports

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1d63ac06c83339849364fe022caf6