### PR TITLE
Add Markdown-backed Lessons page

### DIFF
--- a/app/lessons/page.tsx
+++ b/app/lessons/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getLesson, getLessons } from "@/src/lib/lessons";
+
+export const metadata: Metadata = {
+  title: "Lessons - Guitar Grok",
+  description: "Browse guitar lesson notes and practice plans",
+};
+
+interface LessonsPageProps {
+  searchParams?: {
+    lesson?: string;
+  };
+}
+
+function renderMarkdown(content: string) {
+  const blocks = content.split(/\n{2,}/).map((block) => block.trim()).filter(Boolean);
+
+  return blocks.map((block, index) => {
+    if (block.startsWith("# ")) {
+      return (
+        <h2 key={index} className="text-3xl font-bold">
+          {block.replace(/^#\s+/, "")}
+        </h2>
+      );
+    }
+
+    if (block.startsWith("## ")) {
+      return (
+        <h3 key={index} className="text-2xl font-semibold">
+          {block.replace(/^##\s+/, "")}
+        </h3>
+      );
+    }
+
+    if (block.startsWith("- ")) {
+      return (
+        <ul key={index} className="list-disc space-y-2 pl-6 text-white/85">
+          {block.split("\n").map((item) => (
+            <li key={item}>{item.replace(/^-\s+/, "")}</li>
+          ))}
+        </ul>
+      );
+    }
+
+    return (
+      <p key={index} className="leading-7 text-white/85">
+        {block}
+      </p>
+    );
+  });
+}
+
+export default async function LessonsPage({ searchParams }: LessonsPageProps) {
+  const lessons = await getLessons();
+  const selectedSlug = searchParams?.lesson ?? lessons[0]?.slug;
+  const selectedLesson = selectedSlug ? await getLesson(selectedSlug) : null;
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 px-4 py-8">
+      <div>
+        <p className="text-sm uppercase tracking-[0.3em] text-white/60">Library</p>
+        <h1 className="mt-2 text-4xl font-bold md:text-5xl">Lessons</h1>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[18rem_1fr]">
+        <nav
+          aria-label="Lessons"
+          className="rounded-2xl border border-white/20 bg-white/10 p-3 backdrop-blur"
+        >
+          <div className="mb-3 px-3 text-sm font-semibold text-white/70">Choose a lesson</div>
+          <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-visible">
+            {lessons.map((lesson) => {
+              const isSelected = lesson.slug === selectedLesson?.slug;
+
+              return (
+                <Link
+                  key={lesson.slug}
+                  href={`/lessons?lesson=${lesson.slug}`}
+                  aria-current={isSelected ? "page" : undefined}
+                  className={`whitespace-nowrap rounded-xl px-4 py-3 text-left text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-white/70 ${
+                    isSelected ? "bg-white text-indigo-900" : "bg-white/10 text-white hover:bg-white/20"
+                  }`}
+                >
+                  {lesson.title}
+                </Link>
+              );
+            })}
+          </div>
+        </nav>
+
+        <article className="rounded-2xl border border-white/20 bg-white/10 p-6 backdrop-blur md:p-8">
+          {selectedLesson ? (
+            <div className="space-y-5">{renderMarkdown(selectedLesson.content)}</div>
+          ) : (
+            <p className="text-white/80">Add Markdown files to content/lessons to create lessons.</p>
+          )}
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ interface HomeLink {
 
 const links: HomeLink[] = [
   { href: "/fretboard", title: "Fretboard", description: "Explore notes across the neck" },
+  { href: "/lessons", title: "Lessons", description: "Read lesson notes from Markdown files" },
   {
     href: "/metal-modes/root-b",
     title: "Metal Modes (B)",

--- a/content/lessons/open-position-chords.md
+++ b/content/lessons/open-position-chords.md
@@ -1,0 +1,13 @@
+# Open Position Chords
+
+Build clean chord changes by keeping fingers close to the strings and listening for every note in the shape.
+
+## Practice steps
+
+- Strum each chord once and let it ring for four beats.
+- Switch between Em, G, C, and D with a slow metronome.
+- Increase tempo only after every note sounds clear.
+
+## Focus
+
+Use relaxed shoulders, light thumb pressure, and steady downstrokes.

--- a/content/lessons/pentatonic-box-one.md
+++ b/content/lessons/pentatonic-box-one.md
@@ -1,0 +1,13 @@
+# Pentatonic Box One
+
+The minor pentatonic box is a reliable map for riffs, fills, and first solos.
+
+## Pattern goals
+
+- Say the scale degrees as you play: 1, b3, 4, 5, b7.
+- Alternate pick across the full shape.
+- Create two-bar phrases instead of running the scale up and down.
+
+## Application
+
+Loop a simple backing groove and answer each phrase with a small variation.

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -1,0 +1,71 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface LessonSummary {
+  slug: string;
+  title: string;
+}
+
+export interface Lesson extends LessonSummary {
+  content: string;
+}
+
+const lessonsDirectory = path.join(process.cwd(), "content", "lessons");
+
+function fileNameToSlug(fileName: string): string {
+  return fileName.replace(/\.md$/, "");
+}
+
+function titleFromMarkdown(content: string, slug: string): string {
+  const heading = content
+    .split("\n")
+    .find((line) => line.trim().startsWith("# "))
+    ?.replace(/^#\s+/, "")
+    .trim();
+
+  if (heading) {
+    return heading;
+  }
+
+  return slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export async function getLessons(): Promise<LessonSummary[]> {
+  const files = await readdir(lessonsDirectory);
+  const markdownFiles = files.filter((file) => file.endsWith(".md")).sort();
+
+  return Promise.all(
+    markdownFiles.map(async (fileName) => {
+      const slug = fileNameToSlug(fileName);
+      const content = await readFile(path.join(lessonsDirectory, fileName), "utf8");
+
+      return {
+        slug,
+        title: titleFromMarkdown(content, slug),
+      };
+    }),
+  );
+}
+
+export async function getLesson(slug: string): Promise<Lesson | null> {
+  const safeSlug = slug.replace(/[^a-z0-9-]/gi, "");
+
+  if (!safeSlug) {
+    return null;
+  }
+
+  try {
+    const content = await readFile(path.join(lessonsDirectory, `${safeSlug}.md`), "utf8");
+
+    return {
+      slug: safeSlug,
+      title: titleFromMarkdown(content, safeSlug),
+      content,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple Lessons area so users can browse authored lesson notes and practice plans stored as Markdown files.
- Keep the site style and navigation consistent by adding a left-hand lesson selector and reusing existing layout styles.

### Description
- Add a new page at `app/lessons/page.tsx` that lists lessons in a left navigation panel and renders selected lesson content with a lightweight `renderMarkdown` block parser for headings, paragraphs, and lists.
- Add filesystem helpers in `src/lib/lessons.ts` that read `content/lessons` for lesson summaries and safely load individual lesson content via `getLessons` and `getLesson` (with slug sanitization and title extraction from the first `#` heading).
- Add two starter Markdown lessons under `content/lessons/` (`open-position-chords.md` and `pentatonic-box-one.md`) and add a `Lessons` card to the home dashboard in `app/page.tsx`.

### Testing
- Ran `pnpm test`, which executed the test suite and passed (`1` test file, `3` tests passed).
- Ran `pnpm lint` (Next.js linter) and it completed with no ESLint warnings or errors.
- Ran `pnpm build` (Next.js) and the project compiled and generated the production pages successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e7eb9d6f48333995b1d1c91476bf7)