### PR TITLE
Extract LessonsNav component and refine Lessons page layout and Markdown styling

### DIFF
--- a/app/lessons/LessonsNav.tsx
+++ b/app/lessons/LessonsNav.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { LessonSummary } from "@/src/lib/lessons";
+
+interface LessonsNavProps {
+  lessons: LessonSummary[];
+  selectedSlug?: string;
+}
+
+export default function LessonsNav({ lessons, selectedSlug }: LessonsNavProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedLesson = lessons.find((lesson) => lesson.slug === selectedSlug);
+
+  return (
+    <nav
+      aria-label="Lessons"
+      className="min-w-0 rounded-2xl border border-white/20 bg-white/10 p-3 backdrop-blur"
+    >
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls="lessons-nav-list"
+        className="flex w-full items-center justify-between gap-3 rounded-xl bg-white/10 px-4 py-3 text-left text-sm font-semibold text-white/90 transition hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-white/70 md:hidden"
+        onClick={() => setIsOpen((currentIsOpen) => !currentIsOpen)}
+      >
+        <span className="min-w-0 truncate">{selectedLesson?.title ?? "Choose a lesson"}</span>
+        <span aria-hidden="true" className={`shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}>
+          ▾
+        </span>
+      </button>
+
+      <div className="mb-3 hidden px-3 text-sm font-semibold text-white/70 md:block">Choose a lesson</div>
+      <div
+        id="lessons-nav-list"
+        className={`${isOpen ? "mt-3 flex" : "hidden"} min-w-0 gap-2 overflow-x-auto pb-1 md:mt-0 md:flex md:flex-col md:overflow-visible md:pb-0`}
+      >
+        {lessons.map((lesson) => {
+          const isSelected = lesson.slug === selectedSlug;
+
+          return (
+            <Link
+              key={lesson.slug}
+              href={`/lessons?lesson=${lesson.slug}`}
+              aria-current={isSelected ? "page" : undefined}
+              className={`max-w-[78vw] shrink-0 truncate whitespace-nowrap rounded-xl px-4 py-3 text-left text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-white/70 md:max-w-full ${
+                isSelected ? "bg-white text-indigo-900" : "bg-white/10 text-white hover:bg-white/20"
+              }`}
+              onClick={() => setIsOpen(false)}
+            >
+              {lesson.title}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/app/lessons/page.tsx
+++ b/app/lessons/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import LessonsNav from "./LessonsNav";
 import { getLesson, getLessons } from "@/src/lib/lessons";
 
 export const metadata: Metadata = {
@@ -20,16 +20,16 @@ function LessonMarkdown({ content }: { content: string }) {
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
-        h1: ({ children }) => <h2 className="text-3xl font-bold">{children}</h2>,
-        h2: ({ children }) => <h3 className="text-2xl font-semibold">{children}</h3>,
-        h3: ({ children }) => <h4 className="text-xl font-semibold">{children}</h4>,
-        p: ({ children }) => <p className="leading-7 text-white/85">{children}</p>,
+        h1: ({ children }) => <h2 className="break-words text-2xl font-bold leading-tight sm:text-3xl">{children}</h2>,
+        h2: ({ children }) => <h3 className="break-words text-xl font-semibold leading-tight sm:text-2xl">{children}</h3>,
+        h3: ({ children }) => <h4 className="break-words text-lg font-semibold leading-tight sm:text-xl">{children}</h4>,
+        p: ({ children }) => <p className="break-words leading-7 text-white/85">{children}</p>,
         ul: ({ children }) => <ul className="list-disc space-y-2 pl-6 text-white/85">{children}</ul>,
         ol: ({ children }) => <ol className="list-decimal space-y-2 pl-6 text-white/85">{children}</ol>,
         strong: ({ children }) => <strong className="font-semibold text-white">{children}</strong>,
         hr: () => <hr className="border-white/15" />,
         pre: ({ children }) => (
-          <pre className="overflow-x-auto rounded-xl bg-black/40 p-4 text-sm leading-6 text-white/90">
+          <pre className="max-w-full overflow-x-auto rounded-xl bg-black/40 p-4 text-sm leading-6 text-white/90">
             {children}
           </pre>
         ),
@@ -47,41 +47,18 @@ export default async function LessonsPage({ searchParams }: LessonsPageProps) {
   const selectedLesson = selectedSlug ? await getLesson(selectedSlug) : null;
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 px-4 py-8">
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 overflow-x-hidden px-4 py-8">
       <div>
         <p className="text-sm uppercase tracking-[0.3em] text-white/60">Library</p>
-        <h1 className="mt-2 text-4xl font-bold md:text-5xl">Lessons</h1>
+        <h1 className="mt-2 text-4xl font-bold leading-tight md:text-5xl">Lessons</h1>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-[18rem_1fr]">
-        <nav
-          aria-label="Lessons"
-          className="rounded-2xl border border-white/20 bg-white/10 p-3 backdrop-blur"
-        >
-          <div className="mb-3 px-3 text-sm font-semibold text-white/70">Choose a lesson</div>
-          <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-visible">
-            {lessons.map((lesson) => {
-              const isSelected = lesson.slug === selectedLesson?.slug;
+      <div className="grid min-w-0 gap-4 md:grid-cols-[18rem_minmax(0,1fr)]">
+        <LessonsNav lessons={lessons} selectedSlug={selectedLesson?.slug} />
 
-              return (
-                <Link
-                  key={lesson.slug}
-                  href={`/lessons?lesson=${lesson.slug}`}
-                  aria-current={isSelected ? "page" : undefined}
-                  className={`whitespace-nowrap rounded-xl px-4 py-3 text-left text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-white/70 ${
-                    isSelected ? "bg-white text-indigo-900" : "bg-white/10 text-white hover:bg-white/20"
-                  }`}
-                >
-                  {lesson.title}
-                </Link>
-              );
-            })}
-          </div>
-        </nav>
-
-        <article className="rounded-2xl border border-white/20 bg-white/10 p-6 backdrop-blur md:p-8">
+        <article className="min-w-0 overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur sm:p-6 md:p-8">
           {selectedLesson ? (
-            <div className="space-y-5">
+            <div className="min-w-0 space-y-5">
               <LessonMarkdown content={selectedLesson.content} />
             </div>
           ) : (


### PR DESCRIPTION
### Motivation
- Consolidate lesson navigation into a reusable client component to simplify the page and improve mobile behavior.
- Improve responsive layout and prevent horizontal overflow by tightening layout constraints and adding `min-w-0`/overflow rules.
- Improve Markdown rendering for better line wrapping and readable headings across screen sizes.

### Description
- Adds a new client component `LessonsNav` (`app/lessons/LessonsNav.tsx`) that implements a mobile toggle, selected-state styling, and responsive link list using the provided `lessons` and `selectedSlug` props.
- Replaces the inline lessons nav in `app/lessons/page.tsx` with the `LessonsNav` component and updates the grid column definition to `md:grid-cols-[18rem_minmax(0,1fr)]` to avoid overflow.
- Adjusts layout classes in `app/lessons/page.tsx` including `overflow-x-hidden`, `min-w-0` on containers, and updated article padding and sizing to prevent horizontal scroll.
- Refines `LessonMarkdown` rendering in `app/lessons/page.tsx` with `break-words` and `leading-tight` on heading and paragraph elements and adds `max-w-full` to `pre` blocks to handle long code lines.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ecc2cdd388333bc6f6142930f7a63)